### PR TITLE
Exec receives source as a param

### DIFF
--- a/src/exec/exec.ts
+++ b/src/exec/exec.ts
@@ -10,8 +10,8 @@ function get(target, key) {
     return target[key]
 }
 
-const exec: Exec = ({source , interceptors}): Sandbox => {
-    const interceptedSource = runInterceptors({source : source, interceptors : interceptors})
+const exec: Exec = (source , options): Sandbox => {
+    const interceptedSource = runInterceptors({source : source, interceptors : options?.interceptors})
     const proxiesCache = new WeakMap()
     const sourceWithSand: Source = `with (sandbox) { ${interceptedSource} }`
     const executableCode = new Function('sandbox', sourceWithSand)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,7 @@ export type Source = string;
 export type Sandbox = (sandbox: Record<string | number | symbol, any>) => any;
 export type Interceptor = (source: Source) => Source
 export type Interceptors = Array<Interceptor>
-interface ExecArgs {
-    source: Source;
+interface ExecOptions {
     interceptors?: Interceptors;
 }
-export type Exec = (ExecArgs) => Sandbox;
+export type Exec = (source : Source , execOptions?: ExecOptions) => Sandbox;


### PR DESCRIPTION
 - Source is recieved in `exec` as the first parameter
 - `interceptors` are recieved in the object parameter (as properties)