### PR TITLE
Mistakes in README are fixed:

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ import { exec } from "js-exec";
 
 const source = `console.log("Hello from js-exec 👋");`;
 
-const sandbox = exec(code, {
+const sandbox = exec(source, {
   onSuccess: () => console.log("Taadaa 🎉🎉"),
   onError: (e: Error) => console.log("Something occurred 🥺\n", e),
 });
 
-sandbox();
+sandbox({});
 // Something occurred 🥺
 // TypeError: Cannot read property 'log' of undefined
 


### PR DESCRIPTION
 - `code` variable is renamed to `source`
 - Empty sandbox parameters is changed to `sandbox({})`