### PR TITLE
Added a `pub` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "dev": "tsc -w",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "pub" : "tsc & npm version patch & npm publish"
   },
   "devDependencies": {
     "eslint": "7.31.0",


### PR DESCRIPTION
The 1.2.2 release was published without build. I hope adding this will help avoid such a mistake